### PR TITLE
Use correct CASE

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine as build
+FROM node:20-alpine AS build
 
 # Create app directory
 RUN mkdir -p /usr/src/app


### PR DESCRIPTION
Docker buildx complains about "AS" beeing lowercase

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated the Dockerfile to enhance readability by changing the case of the "as" keyword in the multi-stage build definition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->